### PR TITLE
Add resilient plugin loading

### DIFF
--- a/src/proxy/plugin_manager.py
+++ b/src/proxy/plugin_manager.py
@@ -36,15 +36,20 @@ class PluginManager:
         import pkgutil
 
         package = "proxy.plugins"
-        package_obj = __import__(package, fromlist=['*'])
-        for _, module_name, _ in pkgutil.iter_modules(package_obj.__path__, package + "."):
-            module = importlib.import_module(module_name)
-            if hasattr(module, "Plugin"):
-                cls = getattr(module, "Plugin")
-                if not issubclass(cls, BasePlugin):
-                    continue
-                instance = cls(self)
-                self.register_plugin(instance)
+        package_obj = __import__(package, fromlist=["*"])
+        for _, module_name, _ in pkgutil.iter_modules(
+            package_obj.__path__, package + "."
+        ):
+            try:
+                module = importlib.import_module(module_name)
+                if hasattr(module, "Plugin"):
+                    cls = getattr(module, "Plugin")
+                    if not issubclass(cls, BasePlugin):
+                        continue
+                    instance = cls(self)
+                    self.register_plugin(instance)
+            except Exception as exc:
+                print(f"Failed to load plugin {module_name}: {exc}")
 
     def load_external_plugins(self, path: str) -> None:
         """Load plugins from an external directory.
@@ -143,4 +148,8 @@ class PluginManager:
         func = self.command_registry.get(cmd)
         if func is None:
             return f"Unknown command: {cmd}"
-        return func(args)
+        try:
+            return func(args)
+        except Exception as exc:
+            return f"Error executing {cmd}: {exc}"
+


### PR DESCRIPTION
## Summary
- Guard built-in plugin imports to prevent server startup failures
- Return helpful errors when plugin CLI commands raise exceptions

## Testing
- `PYTHONPATH=src python -m proxy.server --help`
- `PYTHONPATH=src python - <<'PY'
from proxy.plugin_manager import PluginManager
mgr = PluginManager()
mgr.load_builtin_plugins()
print('plugins', [p.name for p in mgr.plugins])
print('cmd', mgr.dispatch_command('show-firewall-rules'))
PY`
