### PR TITLE
Add root server runner and usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,18 @@ MultiProxy/
 
 2. **Run the proxy server**
 
-   Start the proxy on port 8080 (or any port of your choosing) with:
+    Start the proxy on port 8080 (or any port of your choosing) with:
 
-   ```bash
-   python -m proxy.server --listen 0.0.0.0:8080
-   ```
+    ```bash
+    python -m proxy.server --listen 0.0.0.0:8080
+    ```
+
+    A convenience wrapper is also provided so the server can be launched
+    directly from the repository root:
+
+    ```bash
+    python main.py --listen 0.0.0.0:8080
+    ```
 
    You can then configure your web browser or application to use `http://localhost:8080` as its HTTP proxy. Note that HTTPS tunnelling (`CONNECT`) is not implemented for brevity.
 
@@ -72,7 +79,28 @@ MultiProxy/
 
 4. **Extending the proxy**
 
-   Read the documentation in `docs/plugin_system.md` to learn how to implement your own plugins. By placing additional modules into a `plugins` directory and exporting a `Plugin` class, your custom logic will be loaded automatically at startup.
+    Read the documentation in `docs/plugin_system.md` to learn how to implement your own plugins. By placing additional modules into a `plugins` directory and exporting a `Plugin` class, your custom logic will be loaded automatically at startup.
+
+## Using as a Library
+
+The proxy server can also be embedded into your own applications.  Add the
+`src` directory to `PYTHONPATH` (or run your script from the repository root so
+`main.py` can adjust it for you) and import `ProxyServer`:
+
+```python
+import asyncio
+from proxy import ProxyServer
+
+async def start():
+    server = ProxyServer("127.0.0.1", 8080, plugins_dir="./my_plugins")
+    await server.run()
+
+if __name__ == "__main__":
+    asyncio.run(start())
+```
+
+This approach allows you to customise the server instance, specify different
+plugin directories or integrate it with other components within your program.
 
 ## Support
 

--- a/main.py
+++ b/main.py
@@ -1,0 +1,24 @@
+"""Convenience entry point for running the proxy server.
+
+This script ensures the project's ``src`` directory is on ``sys.path`` so
+that the ``proxy`` package can be imported without installation.  It then
+invokes :func:`proxy.server.main` which exposes the same command line
+interface as ``python -m proxy.server``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Add the src directory to sys.path to make ``proxy`` importable
+ROOT = Path(__file__).resolve().parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from proxy.server import main as run_server  # noqa: E402
+
+
+if __name__ == "__main__":
+    run_server()

--- a/main.py
+++ b/main.py
@@ -12,10 +12,10 @@ import sys
 from pathlib import Path
 
 # Add the src directory to sys.path to make ``proxy`` importable
-ROOT = Path(__file__).resolve().parent
-SRC = ROOT / "src"
-if str(SRC) not in sys.path:
-    sys.path.insert(0, str(SRC))
+root = Path(__file__).resolve().parent
+src = root / "src"
+if str(src) not in sys.path:
+    sys.path.insert(0, str(src))
 
 from proxy.server import main as run_server  # noqa: E402
 


### PR DESCRIPTION
## Summary
- Add `main.py` wrapper to run the proxy server from repo root
- Document running via `main.py` and importing `ProxyServer` in user programs

## Testing
- `python main.py --help`
- `python -m py_compile main.py`
